### PR TITLE
Events manager doc fix

### DIFF
--- a/en/api/Phalcon_Events_Manager.rst
+++ b/en/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/es/api/Phalcon_Events_Manager.rst
+++ b/es/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/fr/api/Phalcon_Events_Manager.rst
+++ b/fr/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/ja/api/Phalcon_Events_Manager.rst
+++ b/ja/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/pl/api/Phalcon_Events_Manager.rst
+++ b/pl/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/pt/api/Phalcon_Events_Manager.rst
+++ b/pt/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/ru/api/Phalcon_Events_Manager.rst
+++ b/ru/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 

--- a/zh/api/Phalcon_Events_Manager.rst
+++ b/zh/api/Phalcon_Events_Manager.rst
@@ -14,7 +14,7 @@ Phalcon Events Manager, offers an easy way to intercept and manipulate, if neede
 Methods
 -------
 
-public  **attach** (*string* $eventType, *object|callable* $handler, [*int* $priority])
+public  **attach** (*string* $eventType, *object* $handler, [*int* $priority])
 
 Attach a listener to the events manager
 


### PR DESCRIPTION
According to code it accepts only object as second argument, not object|callable:

if typeof handler != "object" {
    throw new Exception("Event handler must be an Object");
}
